### PR TITLE
Dockerfile: Debian buster based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:buster
+RUN apt-get -y update
+
+RUN apt-get -y install \
+    curl \
+    tar \
+    cmake \
+    make \
+    gcc \
+    gdb \
+    g++ \
+    libboost-all-dev
+
+WORKDIR /usr/src/lib-tdt
+COPY . ./
+RUN mkdir build && \
+  cd build && \
+  export CMAKE_BUILD_PARALLEL_LEVEL=$(($(nproc)*4)) && \
+  cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release && \
+  cmake --build . --clean-first --config Release


### PR DESCRIPTION
* Not everyone has access to RHEL. This image based on Debian
  successfully builds lib-tdt.

Signed-off-by: John Andersen <john.s.andersen@intel.com>